### PR TITLE
Kafka update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Two solutions are provided:
 ## Requirements
 
 - Java 8
-- Kafka 2.2.0
+- Kafka 3.0.0
 
 ## Installation
 

--- a/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaConsumer.java
+++ b/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaConsumer.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -301,6 +301,11 @@ public class TracingKafkaConsumer<K, V> implements Consumer<K, V> {
   }
 
   @Override
+  public OptionalLong currentLag(TopicPartition topicPartition) {
+    return consumer.currentLag(topicPartition);
+  }
+
+  @Override
   public ConsumerGroupMetadata groupMetadata() {
     return consumer.groupMetadata();
   }
@@ -313,12 +318,6 @@ public class TracingKafkaConsumer<K, V> implements Consumer<K, V> {
   @Override
   public void close() {
     consumer.close();
-  }
-
-  @Override
-  @Deprecated
-  public void close(long l, TimeUnit timeUnit) {
-    consumer.close(l, timeUnit);
   }
 
   @Override

--- a/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaConsumer.java
+++ b/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaConsumer.java
@@ -316,6 +316,11 @@ public class TracingKafkaConsumer<K, V> implements Consumer<K, V> {
   }
 
   @Override
+  public void enforceRebalance(String s) {
+    consumer.enforceRebalance(s);
+  }
+
+  @Override
   public void close() {
     consumer.close();
   }

--- a/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaProducer.java
+++ b/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaProducer.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -164,11 +163,6 @@ public class TracingKafkaProducer<K, V> implements Producer<K, V> {
   @Override
   public void close(Duration duration) {
     producer.close(duration);
-  }
-
-  @Override
-  public void close(long timeout, TimeUnit timeUnit) {
-    producer.close(timeout, timeUnit);
   }
 
 }

--- a/opentracing-kafka-spring/src/test/java/io/opentracing/contrib/kafka/spring/TracingSpringKafkaTest.java
+++ b/opentracing-kafka-spring/src/test/java/io/opentracing/contrib/kafka/spring/TracingSpringKafkaTest.java
@@ -20,12 +20,18 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,14 +45,25 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ContextConfiguration(classes = {TestConfiguration.class})
 public class TracingSpringKafkaTest {
 
-  @ClassRule
-  public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(2, true, 2, "spring");
-
   @Autowired
   private MockTracer mockTracer;
 
   @Autowired
   private KafkaTemplate<Integer, String> kafkaTemplate;
+
+  public static EmbeddedKafkaCluster cluster;
+
+  @BeforeClass
+  public static void init() throws InterruptedException, IOException {
+    cluster = new EmbeddedKafkaCluster(2);
+    cluster.start();
+    cluster.createTopic("spring", 2, 2);
+  }
+
+  @AfterClass
+  public static void shutdown() {
+    cluster.stop();
+  }
 
   @Before
   public void before() {

--- a/opentracing-kafka-streams/src/main/java/io/opentracing/contrib/kafka/streams/TracingKafkaClientSupplier.java
+++ b/opentracing-kafka-streams/src/main/java/io/opentracing/contrib/kafka/streams/TracingKafkaClientSupplier.java
@@ -25,6 +25,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.BiFunction;
+
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -87,6 +89,13 @@ public class TracingKafkaClientSupplier implements KafkaClientSupplier {
       BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider,
       BiFunction<String, ProducerRecord, String> producerSpanNameProvider) {
     this(GlobalTracer.get(), null, consumerSpanNameProvider, producerSpanNameProvider);
+  }
+
+  // This method is required by Kafka Streams >=3.0
+  @Override
+  public Admin getAdmin(final Map<String, Object> config) {
+    // create a new client upon each call; but expect this call to be only triggered once so this should be fine
+    return Admin.create(config);
   }
 
   // This method is required by Kafka Streams >=1.1, and optional for Kafka Streams <1.1

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <opentracing.version>0.33.0</opentracing.version>
-    <kafka.version>2.6.0</kafka.version>
+    <kafka.version>3.0.0</kafka.version>
     <spring.kafka.version>2.6.1</spring.kafka.version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
@@ -155,6 +155,14 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams</artifactId>
       <version>${kafka.version}</version>
       <classifier>test</classifier>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <opentracing.version>0.33.0</opentracing.version>
-    <kafka.version>3.0.0</kafka.version>
+    <kafka.version>3.2.0</kafka.version>
     <spring.kafka.version>2.6.1</spring.kafka.version>
     <spring.version>5.2.7.RELEASE</spring.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>


### PR DESCRIPTION
This PR contains the changes that were made by Jakub to make opentracing java client support Kafka 3.0.0

1st commit contains changes made by Jakub for supporting Kafka 3.0.0
2nd commit contains the changes for updating to Kafka 3..2.0 (Added the method `enforceRebalance(String s)  method in `TracingKafkaConsumer` which Kafka 3.2.0 has added in the Consumer interface since `TracingKafkaConsumer` class is implementing the methods from `Consumer` Interface.